### PR TITLE
unprepare hook: exitcode and throws error

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ function prepare(onPrepare, onUnprepare) {
                 done(); // unreachable. test purpose only.
             } else {
                 // Call the actual run().
-                run.call(self, function () {
+                run.call(self, function (exitcode) {
                     // All test complete with a result code.
                     // Pass forward the arugments for possible spec change
                     // in the future.
@@ -26,10 +26,14 @@ function prepare(onPrepare, onUnprepare) {
                     if (typeof onUnprepare === 'function') {
                         // onUnprepare() is supplied. Call it.
                         var args = arguments;
-                        onUnprepare(function () {
+                        onUnprepare(function (err) {
+                            if (err instanceof Error) {
+                                console.error(err.stack);
+                                process.exit(1);
+                            }
                             // Done.
                             done.apply(thisArg, args);
-                        });
+                        }, exitcode);
                     } else {
                         // Done.
                         done.apply(thisArg, arguments);


### PR DESCRIPTION
Purpose: returns exitcode in unprepare hook and throws error if unprepare hook receive an error by param.

Scenario 1:
I need to gracefully close some connections but someone returns an error, then pass by done callback in unprepare context the error.

Scenario 2:
I need to get the Mocha assertion exit code to do some logic issue in unprepare context.
